### PR TITLE
dump report table to file 

### DIFF
--- a/report/Report.cpp
+++ b/report/Report.cpp
@@ -128,24 +128,6 @@ bool is_in(std::string str, std::vector<std::string> &vec) {
   return std::find(vec.begin(), vec.end(), str) != vec.end();
 }
 
-/**
- * @brief Get the filename from a path
- * @param path: path to get filename from, like /src/proj/filename.cc
- * @return filename like filename.cc is path is correct, otherwise path
- */
-std::string get_filename_from_path(const std::string &path) {
-  char sep = '/';
-
-  // Find the last occurrence of the path separator
-  size_t i = path.rfind(sep, path.length());
-  if (i != std::string::npos) {
-    // Return the substring after the last path separator
-    return (path.substr(i + 1, path.length() - i));
-  }
-
-  return path;
-}
-
 std::vector<Value *> ReportInputs(Function &F, FunctionCallee &ReportParam,
                                   raw_string_ostream &rso,
                                   std::string delimiter) {

--- a/report/Report.cpp
+++ b/report/Report.cpp
@@ -297,6 +297,17 @@ bool ReportPass::runOnFunction(Function &F) {
     InsertSignalBefore(&F, AtexitInst, SIGTERM);
     InsertSignalBefore(&F, AtexitInst, SIGINT);
 
+    // call to set the global dump file name before Atexit Inst
+    std::vector<Type *> SetDumpFnameArgsTys({Type::getInt8PtrTy(Ctx)});
+    FunctionType *SetDumpFnameFTy =
+        FunctionType::get(Type::getVoidTy(Ctx), SetDumpFnameArgsTys, false);
+    FunctionCallee SetDumpFname =
+        M->getOrInsertFunction("set_dump_fname", SetDumpFnameFTy);
+    std::vector<Value *> SetDumpFnameArgs(
+        {MakeGlobalString(M, file_name_wo_ext + ".json")});
+    CallInst::Create(SetDumpFname, SetDumpFnameArgs, "set_dump_fname",
+                     AtexitInst);
+
   } else {
 
     // report param

--- a/report/Report.cpp
+++ b/report/Report.cpp
@@ -315,19 +315,6 @@ bool ReportPass::runOnFunction(Function &F) {
     InsertSignalBefore(&F, AtexitInst, SIGTERM);
     InsertSignalBefore(&F, AtexitInst, SIGINT);
 
-    // call to set the global dump file name before Atexit Inst
-    std::vector<Type *> SetDumpFnameArgsTys({Type::getInt8PtrTy(Ctx)});
-    FunctionType *SetDumpFnameFTy =
-        FunctionType::get(Type::getVoidTy(Ctx), SetDumpFnameArgsTys, false);
-    FunctionCallee SetDumpFname =
-        M->getOrInsertFunction("set_dump_fname", SetDumpFnameFTy);
-
-    std::string filename_wo_path = get_filename_from_path(file_name);
-    std::vector<Value *> SetDumpFnameArgs(
-        {MakeGlobalString(M, filename_wo_path + ".json")});
-    CallInst::Create(SetDumpFname, SetDumpFnameArgs, "set_dump_fname",
-                     AtexitInst);
-
   } else {
 
     // report param

--- a/report/Report.cpp
+++ b/report/Report.cpp
@@ -304,7 +304,7 @@ bool ReportPass::runOnFunction(Function &F) {
     FunctionCallee SetDumpFname =
         M->getOrInsertFunction("set_dump_fname", SetDumpFnameFTy);
     std::vector<Value *> SetDumpFnameArgs(
-        {MakeGlobalString(M, file_name_wo_ext + ".json")});
+        {MakeGlobalString(M, file_name + ".json")});
     CallInst::Create(SetDumpFname, SetDumpFnameArgs, "set_dump_fname",
                      AtexitInst);
 

--- a/report/Report.cpp
+++ b/report/Report.cpp
@@ -128,6 +128,24 @@ bool is_in(std::string str, std::vector<std::string> &vec) {
   return std::find(vec.begin(), vec.end(), str) != vec.end();
 }
 
+/**
+ * @brief Get the filename from a path
+ * @param path: path to get filename from, like /src/proj/filename.cc
+ * @return filename like filename.cc is path is correct, otherwise path
+ */
+std::string get_filename_from_path(const std::string &path) {
+  char sep = '/';
+
+  // Find the last occurrence of the path separator
+  size_t i = path.rfind(sep, path.length());
+  if (i != std::string::npos) {
+    // Return the substring after the last path separator
+    return (path.substr(i + 1, path.length() - i));
+  }
+
+  return path;
+}
+
 std::vector<Value *> ReportInputs(Function &F, FunctionCallee &ReportParam,
                                   raw_string_ostream &rso,
                                   std::string delimiter) {
@@ -303,8 +321,10 @@ bool ReportPass::runOnFunction(Function &F) {
         FunctionType::get(Type::getVoidTy(Ctx), SetDumpFnameArgsTys, false);
     FunctionCallee SetDumpFname =
         M->getOrInsertFunction("set_dump_fname", SetDumpFnameFTy);
+
+    std::string filename_wo_path = get_filename_from_path(file_name);
     std::vector<Value *> SetDumpFnameArgs(
-        {MakeGlobalString(M, file_name + ".json")});
+        {MakeGlobalString(M, filename_wo_path + ".json")});
     CallInst::Create(SetDumpFname, SetDumpFnameArgs, "set_dump_fname",
                      AtexitInst);
 

--- a/reporter.cpp
+++ b/reporter.cpp
@@ -51,7 +51,7 @@ void segfault_handler(int signal_number) { siglongjmp(env, 1); }
 // the fuzzer file will be linked to multiple targets
 // for each target, the table should be dumped once
 thread_local unsigned int dump_counter = 0;
-thread_local char *dump_file_name = nullptr;
+char *dump_file_name = "tmp_dump.json";
 extern "C" void dump_count() {
   if (SILENT_REPORTER)
     return;
@@ -65,6 +65,8 @@ extern "C" void dump_count() {
     printf("Error opening file!\n");
     exit(1);
   }
+
+  cout << "Dumping ReportTable to " << dump_file_name << "\n";
   fprintf(fp, "%s", j.dump().c_str());
   fclose(fp);
   dump_counter++;

--- a/reporter.cpp
+++ b/reporter.cpp
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <nlohmann/json.hpp>


### PR DESCRIPTION
reporter will write a JSON file named `fuzzer_name.ext.json`, there will be one file per fuzzer.

fuzzer name is gotten from file name that the `LLVMFuzzerTestOneInput` function ("main" of the fuzzers, where we instrument the `atexit` function) is in. This file name is `/path/to/fuzzer_name.cc`, we only take the `fuzzer_name.cc` part, and name the dump file `fuzzer_name.cc.json`.

To be decided: should the dump file named `fuzzer_name.json` or `fuzzer_name.ext.json`?